### PR TITLE
Fix typo: colmak -> colemak

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-## Colmak-Vim
-This is a fork of the usual VSCodeVim emulator that defines the arrow keys at hnei instead of hjkl so they're in the correct place for colmak.
+## Colemak-Vim
+This is a fork of the usual VSCodeVim emulator that defines the arrow keys at hnei instead of hjkl so they're in the correct place for colemak.
 
-Re-mappings - qwerty -> colmak:
+Re-mappings - qwerty -> colemak:
 * n -> j (down)
 * e -> k (up)
 * i -> l (right)


### PR DESCRIPTION
Hi,

Thank you so much for this! I think there is a typo in the layout name - it should be colemak, not colmak. I could not find a issue tab so I'm creating a PR.

By the way, could you please point me which part of the code I can change to have more comprehensive colemak key layout? (for example, I want to use `d` for `g` so I have the consistent keymap between qwerty and colemak in terms of key locations).

