### PR TITLE
fix J behavior to follow original E

### DIFF
--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -1959,7 +1959,7 @@ export class ActionDeleteLastChar extends BaseCommand {
 @RegisterAction
 class ActionJoin extends BaseCommand {
   modes = [Mode.Normal];
-  keys = ['J'];
+  keys = ['N'];
   override createsUndoPoint = true;
   override runsOnceForEachCountPrefix = false;
 
@@ -2115,7 +2115,7 @@ class ActionJoin extends BaseCommand {
 @RegisterAction
 class ActionJoinVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine];
-  keys = ['J'];
+  keys = ['N'];
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const [start, end] = sorted(vimState.editor.selection.start, vimState.editor.selection.end);
@@ -2131,7 +2131,7 @@ class ActionJoinVisualMode extends BaseCommand {
 @RegisterAction
 class ActionJoinVisualBlockMode extends BaseCommand {
   modes = [Mode.VisualBlock];
-  keys = ['J'];
+  keys = ['N'];
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const [start, end] = sorted(vimState.cursorStartPosition, vimState.cursorStopPosition);
@@ -2184,7 +2184,7 @@ class ActionJoinNoWhitespace extends BaseCommand {
 @RegisterAction
 class ActionJoinNoWhitespaceVisualMode extends BaseCommand {
   modes = [Mode.Visual, Mode.VisualLine, Mode.VisualBlock];
-  keys = ['g', 'J'];
+  keys = ['g', 'N'];
 
   public override async exec(position: Position, vimState: VimState): Promise<void> {
     const [start, end] = sorted(vimState.cursorStartPosition, vimState.cursorStopPosition);

--- a/src/actions/commands/actions.ts
+++ b/src/actions/commands/actions.ts
@@ -2144,7 +2144,7 @@ class ActionJoinVisualBlockMode extends BaseCommand {
 @RegisterAction
 class ActionJoinNoWhitespace extends BaseCommand {
   modes = [Mode.Normal];
-  keys = ['g', 'J'];
+  keys = ['g', 'N'];
   override createsUndoPoint = true;
 
   // gJ is essentially J without the edge cases. ;-)


### PR DESCRIPTION
<!--
Yay! Thanks for sending us a PR! 🎊

Please ensure your PR adheres to:

- [ ] Commit messages has a short & issue references when necessary
- [ ] Each commit does a logical chunk of work.
- [ ] It builds and tests pass (e.g `gulp`)
-->

**What this PR does / why we need it**:
Pressing 'J' (uppercase j) on colemak keyboard does not function properly. It must act as 'E' (move cursor to the end of WORD), but instead it just joins the lines. 

**Which issue(s) this PR fixes**
I figured it is because you did not fix the actions.ts file. I just replaced all the remaining 'J's into 'E's and all others now function properly.

<!--
Commits in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)
-->

**Special notes for your reviewer**:
Thanks for providing this awesome app!